### PR TITLE
Fix for Mac path issue, completed message, done button

### DIFF
--- a/R/photon_rstudioaddin.R
+++ b/R/photon_rstudioaddin.R
@@ -14,7 +14,7 @@ photon_rstudioaddin <- function(RscriptRepository = NULL) {
     # Shiny fileinput resethandler
     
     miniUI::gadgetTitleBar("Use Photon to Build Standalone Shiny Apps",
-                           left = NULL, right = NULL),
+                           left = NULL),
     
     miniUI::miniTabstripPanel(
       #miniUI::miniTabPanel(
@@ -56,10 +56,6 @@ photon_rstudioaddin <- function(RscriptRepository = NULL) {
         )))),
       miniUI::miniButtonBlock(
         actionButton("create", "Build", icon("play-circle"),
-                     style="color: #fff; background-color: #337ab7; border-color: #2e6da4")
-      ),
-      miniUI::miniButtonBlock(
-        actionButton("done", "Done", icon("stop-circle"),
                      style="color: #fff; background-color: #337ab7; border-color: #2e6da4")
       )
   )

--- a/R/photon_rstudioaddin.R
+++ b/R/photon_rstudioaddin.R
@@ -28,6 +28,8 @@ photon_rstudioaddin <- function(RscriptRepository = NULL) {
                  shiny::verbatimTextOutput('currentdirselected')
           ),
         shiny::br(),
+        actionButton("done", "Done",
+                     style="color: #fff; background-color: #337ab7; border-color: #2e6da4")
         shiny::br(),
         shiny::h4("CRAN Packages:"),
         shiny::textInput('cran_packages',
@@ -56,8 +58,6 @@ photon_rstudioaddin <- function(RscriptRepository = NULL) {
         )))),
       miniUI::miniButtonBlock(
         actionButton("create", "Build", icon("play-circle"),
-                     style="color: #fff; background-color: #337ab7; border-color: #2e6da4"),
-        actionButton("done", "Done", icon("stop-circle"),
                      style="color: #fff; background-color: #337ab7; border-color: #2e6da4")
       )
   )

--- a/R/photon_rstudioaddin.R
+++ b/R/photon_rstudioaddin.R
@@ -29,7 +29,7 @@ photon_rstudioaddin <- function(RscriptRepository = NULL) {
           ),
         shiny::br(),
         actionButton("done", "Done",
-                     style="color: #fff; background-color: #337ab7; border-color: #2e6da4")
+                     style="color: #fff; background-color: #337ab7; border-color: #2e6da4"),
         shiny::br(),
         shiny::h4("CRAN Packages:"),
         shiny::textInput('cran_packages',

--- a/R/photon_rstudioaddin.R
+++ b/R/photon_rstudioaddin.R
@@ -56,6 +56,8 @@ photon_rstudioaddin <- function(RscriptRepository = NULL) {
         )))),
       miniUI::miniButtonBlock(
         actionButton("create", "Build", icon("play-circle"),
+                     style="color: #fff; background-color: #337ab7; border-color: #2e6da4"),
+        actionButton("done", "Done", icon("stop-circle"),
                      style="color: #fff; background-color: #337ab7; border-color: #2e6da4")
       )
   )

--- a/R/photon_rstudioaddin.R
+++ b/R/photon_rstudioaddin.R
@@ -28,8 +28,6 @@ photon_rstudioaddin <- function(RscriptRepository = NULL) {
                  shiny::verbatimTextOutput('currentdirselected')
           ),
         shiny::br(),
-        actionButton("done", "Done",
-                     style="color: #fff; background-color: #337ab7; border-color: #2e6da4"),
         shiny::br(),
         shiny::h4("CRAN Packages:"),
         shiny::textInput('cran_packages',
@@ -58,6 +56,10 @@ photon_rstudioaddin <- function(RscriptRepository = NULL) {
         )))),
       miniUI::miniButtonBlock(
         actionButton("create", "Build", icon("play-circle"),
+                     style="color: #fff; background-color: #337ab7; border-color: #2e6da4")
+      ),
+      miniUI::miniButtonBlock(
+        actionButton("done", "Done", icon("stop-circle"),
                      style="color: #fff; background-color: #337ab7; border-color: #2e6da4")
       )
   )

--- a/R/startFun.R
+++ b/R/startFun.R
@@ -160,6 +160,7 @@ startFun <- function(input_path, cran_packages=NULL, bioc_packages=NULL, github_
     system(sprintf("cd %s; npm install; npm run package-mac", 
                    r_portable_path))
   }
+  message("Photon finished")
 }
 
 

--- a/R/startFun.R
+++ b/R/startFun.R
@@ -118,7 +118,7 @@ startFun <- function(input_path, cran_packages=NULL, bioc_packages=NULL, github_
     
     
   } else if(.Platform$OS.type=="unix") {
-    r_portable_path <- normalizePath(file.path(input_path, "R-Portable-Mac"))
+    r_portable_path <- normalizePath(file.path(electron_path, "R-Portable-Mac"))
     
     
     r_electron_version <- system(sprintf("cd %s; ./R CMD BATCH --version", 


### PR DESCRIPTION
Mac paths were setup wrong, changed the code to match the Win version.
No clear message that the build was finished, so added the message
Done button method existed, but was not enabled in the UI, so added that.